### PR TITLE
Use build_arty directory for loading and flashing

### DIFF
--- a/arty.py
+++ b/arty.py
@@ -101,15 +101,15 @@ def main():
     if args.load:
         from litex.build.openocd import OpenOCD
         prog = OpenOCD("prog/openocd_xilinx.cfg")
-        prog.load_bitstream("build/gateware/top.bit")
+        prog.load_bitstream("build_arty/gateware/top.bit")
 
     if args.flash:
         flash_regions = {
-            "build/gateware/top.bin": "0x00000000", # FPGA image: automatically loaded at startup
-            "binaries/Image":         "0x00400000", # Linux Image: copied to 0xc0000000 by bios
-            "binaries/rootfs.cpio":   "0x00800000", # File System: copied to 0xc2000000 by bios
-            "binaries/rv32.dtb":      "0x00f00000", # Device tree: copied to 0xc3000000 by bios
-            "emulator/emulator.bin":  "0x00f80000", # MM Emulator: copied to 0x20000000 by bios
+            "build_arty/gateware/top.bin": "0x00000000", # FPGA image: automatically loaded at startup
+            "binaries/Image":              "0x00400000", # Linux Image: copied to 0xc0000000 by bios
+            "binaries/rootfs.cpio":        "0x00800000", # File System: copied to 0xc2000000 by bios
+            "binaries/rv32.dtb":           "0x00f00000", # Device tree: copied to 0xc3000000 by bios
+            "emulator/emulator.bin":       "0x00f80000", # MM Emulator: copied to 0x20000000 by bios
         }
         from litex.build.openocd import OpenOCD
         prog = OpenOCD("prog/openocd_xilinx.cfg",


### PR DESCRIPTION
The Arty and Versa builds have their own build output directories, but arty.py uses the "build" directory instead of the "build_arty" directory.