### PR TITLE
Fix timebase-frequency in .dts for Arty.

### DIFF
--- a/buildroot/board/litex_vexriscv/litex_vexriscv_arty.dts
+++ b/buildroot/board/litex_vexriscv/litex_vexriscv_arty.dts
@@ -15,7 +15,7 @@
 	cpus {
 		#address-cells = <0x1>;
 		#size-cells = <0x0>;
-		timebase-frequency = <0x47868C0>;
+		timebase-frequency = <100000000>;
 
 		cpu@0 {
 			clock-frequency = <0x0>;


### PR DESCRIPTION
The system clock frequency is 100 MHz not 75 MHz.