### PR TITLE
fixup 'make liteeth work' PR

### DIFF
--- a/buildroot/board/litex_vexriscv/litex-vexriscv-linux.dtsi
+++ b/buildroot/board/litex_vexriscv/litex-vexriscv-linux.dtsi
@@ -36,6 +36,7 @@
 	soc {
 		#address-cells = <0x2>;
 		#size-cells = <0x2>;
+		compatible = "simple-bus";
 		ranges;
 
 		mac0: mac@f0003800 {


### PR DESCRIPTION
@enjoy-digital 
Sorry,  but the commit 5e0fe1b4f27f ('dts: use feasable model and compatible strings, drop sifive mentions') "throws the baby out with the bathwater". It drops necessary "simple-bus" 'compatible' value together with SiFive-related values. As a result liteeth driver is never probed.

This PR fixes the problem.